### PR TITLE
Update e2e lab to support the latest version of OpenNMS and Kafka.

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,11 +9,9 @@ volumes:
 services:
 
   zookeeper:
-    image: zookeeper:3.5
+    image: zookeeper:3.8
     container_name: zookeeper
     hostname: zookeeper
-    ports:
-    - 8080:8080
     volumes:
     - zookeeper:/data
     environment:
@@ -29,7 +27,7 @@ services:
       retries: 3
 
   kafka:
-    image: bitnami/kafka:2.8.1
+    image: bitnami/kafka:3.3
     container_name: kafka
     hostname: kafka
     depends_on:
@@ -103,7 +101,7 @@ services:
       retries: 3
 
   opennms:
-    image: opennms/horizon:28.1.1
+    image: opennms/horizon:30.0.4
     container_name: opennms
     hostname: opennms
     depends_on:
@@ -320,7 +318,7 @@ services:
     - ./gominion-cfg/grpc.yaml:/gominion.yaml
 
   minion:
-    image: opennms/minion:28.1.1
+    image: opennms/minion:30.0.4
     container_name: minion
     hostname: minion
     depends_on:
@@ -339,11 +337,8 @@ services:
     - ./minion-etc:/opt/minion-etc-overlay
     environment:
     - TZ=America/New_York
-    - OPENNMS_HTTP_USER=admin
-    - OPENNMS_HTTP_PASS=admin
     - MINION_ID=minion-java
     - MINION_LOCATION=Apex
-    - OPENNMS_HTTP_URL=http://opennms:8980/opennms
     healthcheck:
       test: /health.sh
       interval: 1m

--- a/docker/minion-etc/featuresBoot.d/kafka.boot
+++ b/docker/minion-etc/featuresBoot.d/kafka.boot
@@ -1,5 +1,3 @@
 !minion-jms
-!opennms-core-ipc-sink-camel
-!opennms-core-ipc-rpc-jms
-opennms-core-ipc-sink-kafka
-opennms-core-ipc-rpc-kafka
+!opennms-core-ipc-jms
+opennms-core-ipc-kafka

--- a/docker/minion-etc/org.opennms.core.ipc.twin.kafka.cfg
+++ b/docker/minion-etc/org.opennms.core.ipc.twin.kafka.cfg
@@ -1,0 +1,2 @@
+bootstrap.servers=kafka:9092
+request.timeout.ms=30000

--- a/docker/opennms-etc/opennms.properties.d/kafka.properties
+++ b/docker/opennms-etc/opennms.properties.d/kafka.properties
@@ -1,11 +1,11 @@
+# Enable Kafka
+org.opennms.core.ipc.strategy=kafka
 # Disable internal ActiveMQ
 org.opennms.activemq.broker.disable=true
 # Sink
-org.opennms.core.ipc.sink.strategy=kafka
 org.opennms.core.ipc.sink.kafka.bootstrap.servers=kafka:9092
 # RPC
-org.opennms.core.ipc.rpc.strategy=kafka
 org.opennms.core.ipc.rpc.kafka.bootstrap.servers=kafka:9092
 org.opennms.core.ipc.rpc.kafka.ttl=30000
-org.opennms.core.ipc.rpc.kafka.single-topic=true
-org.opennms.core.ipc.rpc.kafka.auto.offset.reset=latest
+# Twin
+org.opennms.core.ipc.twin.kafka.bootstrap.servers=kafka:9092

--- a/docker/opennms-etc/trapd-configuration.xml
+++ b/docker/opennms-etc/trapd-configuration.xml
@@ -1,0 +1,3 @@
+<trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd" snmp-trap-address="*" snmp-trap-port="1162" new-suspect-on-trap="false" include-raw-message="false" threads="0" queue-size="10000" batch-size="1000" batch-interval="500">
+    <snmpv3-user security-name="traptest" auth-passphrase="0p3nNMSv3" auth-protocol="SHA-256" privacy-passphrase="0p3nNMSv3" privacy-protocol="DES" />
+</trapd-configuration>


### PR DESCRIPTION
Remember, TWIN API is not supported on gominion.